### PR TITLE
Add a timeout to starting the ConDep node

### DIFF
--- a/src/ConDep.Execution/PSScripts/ConDepNode/ConDepNode.psm1
+++ b/src/ConDep.Execution/PSScripts/ConDepNode/ConDepNode.psm1
@@ -44,9 +44,10 @@ function Start-ConDepNode() {
 
 	if($wmiService) {
 		if($wmiService.State -eq "Stopped") {
-    		$service = Get-Service condepnode -ErrorAction Stop
+			$timeSpan = New-TimeSpan -Minute 1
+    			$service = Get-Service condepnode -ErrorAction Stop
 			$service.Start()
-			$service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Running)
+			$service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Running, $timeSpan)
 		}
 		else {
 			throw "Failed to start ConDepNode Windows service, because it's not stopped. The current state of the service is $($wmiService.State)."


### PR DESCRIPTION
There exists a race condition in this code where the ConDep service can stop executing immediately after starting. In this case the WaitForStatus will never see the service become running and hang indefinitely. Adding this timeout will make it fail after a minute.